### PR TITLE
STW-76 Condition Injection

### DIFF
--- a/src/nonlinear_system.jl
+++ b/src/nonlinear_system.jl
@@ -16,3 +16,51 @@ function dynamic_surface_condition(u,N,m)
         Σ₃ = sum([j*stream_eigenfunction(sinh,sin,u,N,m,j) for j in 1:N])
         return (-u[2N+6] + Σ₂)^2 / 2 + Σ₃^2 / 2 + u[m+1] - u[2N+3] - u[2N+5]
 end
+
+function euler_condition(u,N)
+    return u[2N+6] - u[2N+2]
+end
+
+function stokes_condition(u,N)
+    return euler_condition(u,N) - u[2N+4] / u[2N+3]
+end
+
+function length_condition(u,N,p)
+    return u[2N+3] - 2π / p
+end
+
+function period_condition(u,N,p)
+    return u[2N+2] * p * √u[2N+3] - 2π   
+end
+
+
+include("params.jl") 
+function current_criterion(cc)
+    if Int(cc) == Int(CC_STOKES)
+        return stokes_condition
+    elseif Int(cc) == Int(CC_EULER)
+        return euler_condition
+    else
+        throw(error("Unknown current criterion $cc"))
+    end
+end
+
+function parameter_criterion(pc)
+    if Int(pc) == Int(PC_LENGTH)
+        return length_condition
+    elseif Int(pc) == Int(PC_PERIOD)
+        return period_condition
+    else
+        throw(error("Unknown parameter criterion $pc"))
+    end
+end
+
+function parameter_criterion_constant(pc, P, d, g)
+    if Int(pc) == Int(PC_LENGTH)
+        return  P / d
+    elseif Int(pc) == Int(PC_PERIOD)
+        return P * sqrt(g / d) 
+    else
+        throw(error("Unknown parameter criterion $pc"))
+    end
+end


### PR DESCRIPTION
Introduction of functions for parameter conditions, current conditions, wave power and wave height. 

Parameter conditions `length_condition` , `period_condition`  and current conditions `euler_condition`, `stokes_condition` can be selected using a proxy function taking respectively `cc` or `pc` as arguments.
Then conditions can be injected into `fourier_approx`.

Implementations of `wave_power_condition` and `wave_height_condition` are specific to steady.jl and shoaling.jl due to differences in way that calculation are performed.

As in **STW-75**  commentary on names of function would would be appreciated.