### PR TITLE
STW-77 Inner Modules

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -9,5 +9,11 @@ Pages = ["api.md"]
 ```
 
 ```@autodocs
-Modules = [SteadyWaves]
+Modules = [SteadyWaves,
+    SteadyWaves.NonlinearSystem,
+    SteadyWaves.Output,
+    SteadyWaves.Params,
+    SteadyWaves.Shoaling,
+    SteadyWaves.Steady,
+]
 ```

--- a/src/SteadyWaves.jl
+++ b/src/SteadyWaves.jl
@@ -9,13 +9,24 @@ propagating in water of constant depth.
 """
 module SteadyWaves
 
-using NonlinearSolve
-export fourier_approx, shoaling_approx, wave_number
+include("params.jl")
+using .Params
+
+include("output.jl")
+using .Output
+using .Output: wave_height, wavelength, wave_power, wave_period
+
+include("nonlinear_system.jl")
+
+include("steady.jl")
+using .Steady: fourier_approx, wave_number
+
+include("shoaling.jl")
+using .Shoaling: shoaling_approx, fourier_approx!
+
+export fourier_approx,fourier_approx!, shoaling_approx, wave_number
 export wave_period, wavelength, wave_height
 export CurrentCriterion, CC_EULER, CC_STOKES
 export ParameterCriterion, PC_LENGTH, PC_PERIOD
-
-include("steady.jl")
-include("shoaling.jl")
 
 end

--- a/src/nonlinear_system.jl
+++ b/src/nonlinear_system.jl
@@ -1,5 +1,8 @@
-include("output.jl")
-include("params.jl") 
+module NonlinearSystem
+
+using ..Output
+using ..Output: wave_power, wave_period
+using ..Params
 
 function stream_eigenfunction(hiperbolic,trigonometric,u,N,m,j)
     return u[N+1+j] * hiperbolic(j * u[m+1]) / cosh(j * u[2N+D_INDEX]) * trigonometric(j * m * π / N)
@@ -101,4 +104,6 @@ function nonlinear_system_base!(du, u, N, _height_condition, _parameter_conditio
 
     du[2N+7] = _power_condition(u, N)
     return nothing
+end
+
 end

--- a/src/output.jl
+++ b/src/output.jl
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 # Functions for calculating the output
+module Output
 
 """
 `u[elevation_indexes(N)]`: free surface elevations *kη*
@@ -99,4 +100,10 @@ function wave_power(u, N)
     U_b2 = 2 * bernoulli - celerity^2
     F = celerity * (3E_k - 2E_p) + 0.5 * U_b2 * (I_p + celerity * depth) + celerity * U_e * (velocity * depth - flux)
     return F
+end
+
+export C_INDEX, D_INDEX, H_INDEX, Q_INDEX, R_INDEX, U_INDEX
+
+export elevation_indexes,stream_indexes
+
 end

--- a/src/params.jl
+++ b/src/params.jl
@@ -1,3 +1,4 @@
+module Params
 
 @enum CurrentCriterion begin
     CC_STOKES = 1
@@ -7,4 +8,8 @@ end
 @enum ParameterCriterion begin
     PC_LENGTH = 1
     PC_PERIOD= 2
+end
+export CurrentCriterion, CC_EULER, CC_STOKES
+
+export ParameterCriterion, PC_LENGTH, PC_PERIOD
 end

--- a/src/shoaling.jl
+++ b/src/shoaling.jl
@@ -1,8 +1,14 @@
 # SPDX-License-Identifier: MIT
 
 # Functions for shoaling calculations based on Fourier Approximation Method
-include("nonlinear_system.jl")
+module Shoaling
 
+using ..Output
+using ..Output: wave_power, wave_period
+using ..Params
+using NonlinearSolve
+using ..Steady: fourier_approx
+using ..NonlinearSystem: nonlinear_system_base!, period_condition, power_condition, current_condition_factory, height_condition
 """
     shoaling_approx(d, H, L; cc=2, N=10, g=9.81)
 
@@ -84,4 +90,6 @@ function init_conditions!(ratio_d, u, N)
     u[2N+U_INDEX] /= √ratio_d # Ū√(k/g)
     u[2N+H_INDEX] /= ratio_d # kH
     return nothing
+end
+
 end

--- a/src/steady.jl
+++ b/src/steady.jl
@@ -1,7 +1,13 @@
 # SPDX-License-Identifier: MIT
 
 # Basic functions for Fourier Approximation Method (FAM)
-include("nonlinear_system.jl")
+module Steady
+
+using ..Output
+using ..Params
+using NonlinearSolve
+using ..NonlinearSystem: nonlinear_system_base!, parameter_condition_constant, parameter_condition_factory,
+    current_condition_factory, height_condition
 """
     fourier_approx(d, H, P; pc=1, cc=1, N=10, M=1, g=9.81)
 
@@ -106,4 +112,6 @@ function wave_number(d, ω, g=9.81, ϵ=10^-12)
         k = k₀ / tanh(k * d)
     end
     return k
+end
+
 end


### PR DESCRIPTION
Introduction of modules: `Steady`, `Shoaling`, `NonlinearSystem`, `Output`, `Params`. 

Modules limit visibility of functions and help keep namespace clean. 

They are included in `SteadyWaves.jl` and refereed via `..` in Inner other modules for example `..Output`.
