### PR TITLE
STW-83 change of range to logrange in example3

### DIFF
--- a/docs/examples/shoaling_diagram.jl
+++ b/docs/examples/shoaling_diagram.jl
@@ -1,14 +1,12 @@
 using SteadyWaves
 using CairoMakie
 
-H₀toL₀
+H₀_L₀ = [0.003, 0.005, 0.01, 0.02, 0.03, 0.05] # set wave steepness cases
+d_min = [0.019, 0.0275, 0.046, 0.0784, 0.1091, 0.1714] # set minimal depth values
 
-N_d = 2000 # set number of steps for changing depth
-H_over_L = [0.003, 0.005, 0.01, 0.02, 0.03, 0.05] # set wave stepness cases
-# set minimal values for depth for wave stepness cases H_over_L
-min_d₀ = [0.019, 0.0275, 0.046, 0.0784, 0.1091, 0.1714]
-# create results matrix
-results = zeros(n_steps_d, 2 * length(H_over_L))
+N = 40 # set number of points
+N_d = 600 # set number of steps for changing depth
+results = zeros(N_d, 2 * length(H₀_L₀))
 
 # initial conditions
 g = 9.81 # gravitational acceleration (m/s²)
@@ -16,34 +14,31 @@ d₀ = 1 # water depth (m)
 L₀ = 2 # wavelength (m)
 k₀ = 2π / L₀ # wave number (rad/m)
 ω₀ = √(g * k₀ * tanh(k₀ * d₀)) # angular wave frequency (rad/s)
-H = H_over_d * L₀ # wave height (m)
-N = 40 # number of eigenvalues of solution
+H₀ = H₀_L₀ * L₀ # wave heights (m)
 
-for i in eachindex(H)
-    # initial nonlinear solution
-    range_d = reverse(range(min_d₀[i], 1, N_d)) # water depths range (m)
-    ds = range_d * d₀ # water depths (m)
-    K = shoaling_approx(ds, H[i], L₀; N=N)
-    results[:, 2i-1] = k₀ * ds
+for i in eachindex(H₀)
+    d = reverse(logrange(d_min[i], 1, N_d))  * d₀ # water depths (m)
+    K = shoaling_approx(d, H₀[i], L₀; N=N) # shoaling coefficients
+    # save results
+    results[:, 2i-1] = k₀ * d
     results[:, 2i] = K
-    println(i)
 end
 
-ds = reverse(range(0.01, 1, n_steps_d))
-k = dispersion_relation.(ds, ω₀)
+d = reverse(logrange(0.01, 1, N_d))  * d₀ # water depths (m)
+k = wave_number.(d, ω₀) # linear wave numbers (rad/m)
+# calculate linear shoaling coefficient
+K = @. sqrt((k * (1 + 2k₀ * d₀ / sinh(2k₀ * d₀))) / (k₀ * (1 + 2k * d / sinh(2k * d))))
 
-# initialize figure of size
-fig_width = 5 * 72 # inches x points
-aspect = 1.3
-with_theme(theme_latexfonts()) do
-    fig = Figure(size=(fig_width, fig_width / aspect), fontsize=9, figure_padding=4)
+# CairoMakie figure
+with_theme(theme_latexfonts()) do # use latex theme
+    fig = Figure(size = (400, 300), fontsize = 9)
     ax = Axis(fig[1, 1],
         xlabel=L"$k_0d$",
         xscale=log10,
         xticks=[0.1, 1, 10],
-        ylabel=L"$K_s$",
+        ylabel=L"$K$",
         yscale=log10,
-        yticks=1:0.2:3.4,
+        yticks=1:0.2:2.4,
         limits=(0.04, π, 0.9, 2.4);
         xminorticksvisible=true,
         xminorticks=IntervalsBetween(10),
@@ -52,21 +47,20 @@ with_theme(theme_latexfonts()) do
         yminorticks=IntervalsBetween(4),
         yminorgridvisible=true,
     )
-    lines!(k₀ * ds, @. sqrt((k * (1 + 2k₀ * d₀ / sinh(2k₀ * d₀))) / (k₀ * (1 + 2k * ds / sinh(2k * ds))));
+    lines!(ax, k₀ * d, K;
         color=:tomato,
         linestyle=:dot,
         label="linear theory")
-    for n in 1:length(H_over_L)
-        lines!(results[:, 2n-1], results[:, 2n];
+    for i in eachindex(H₀_L₀)
+        lines!(ax, results[:, 2i-1], results[:, 2i];
             color=:dodgerblue4,
             linestyle=:dash, label="Rienecker and Fenton")
     end
-    text!(ax, min_d₀ * k₀, [2.3, 2.0, 1.6, 1.35, 1.25, 1.1],
-        text=[L"H_0/L_0= %$(H_L)" for H_L in H_over_L],
+    text!(ax, k₀ * d_min, [2.3, 2.0, 1.6, 1.35, 1.25, 1.1],
+        text=[L"H_0/L_0= %$(value)" for value in H₀_L₀],
         offset=(5, 0),
         align=(:left, :center)
     )
     axislegend(ax, position=:rt, unique=true, patchsize=(42, 1))
     fig
-    # save("figures/shoaling_diagram.png", fig, px_per_unit=10, pt_per_unit=1)
 end

--- a/docs/src/guide.md
+++ b/docs/src/guide.md
@@ -106,7 +106,7 @@ We set a number of points `N` for [`shoaling_approx`](@ref) (which uses in-place
 
 ```@example 3
 N = 40 # set number of points
-N_d = 2000 # set number of steps for changing depth
+N_d = 600 # set number of steps for changing depth
 results = zeros(N_d, 2 * length(H₀_L₀))
 nothing # hide
 ```
@@ -128,7 +128,7 @@ We loop over wave cases each time defining a vector of depth values `d` from dee
 
 ```@example 3
 for i in eachindex(H₀)
-    d = reverse(range(d_min[i], 1, N_d))  * d₀ # water depths (m)
+    d = reverse(logrange(d_min[i], 1, N_d))  * d₀ # water depths (m)
     K = shoaling_approx(d, H₀[i], L₀; N=N) # shoaling coefficients
     # save results
     results[:, 2i-1] = k₀ * d
@@ -144,7 +144,7 @@ $$K = \sqrt{\frac{k\left(1+\frac{2k_0d_0}{\sinh2k_0d_0}\right)}{k_0\left(1+\frac
 which is independent of wave steepness $H_0/L_0$.
 
 ```@example 3
-d = reverse(range(0.01, 1, N_d))  * d₀ # water depths (m)
+d = reverse(logrange(0.01, 1, N_d))  * d₀ # water depths (m)
 k = wave_number.(d, ω₀) # linear wave numbers (rad/m)
 # calculate linear shoaling coefficient
 K = @. sqrt((k * (1 + 2k₀ * d₀ / sinh(2k₀ * d₀))) / (k₀ * (1 + 2k * d / sinh(2k * d))))


### PR DESCRIPTION
`range` is changed to `logrange` when calculating shoaling coefficient in example 3 of the documentation
also file shoaling.jl is changed accordingly