### PR TITLE
STW-84 Naming Convention

### DIFF
--- a/src/nonlinear_system.jl
+++ b/src/nonlinear_system.jl
@@ -50,7 +50,7 @@ function period_condition(u,N,p)
     return u[2N+C_INDEX] * p * √u[2N+D_INDEX] - 2π   
 end
 
-function current_criterion(cc)
+function current_condition_factory(cc)
     if Int(cc) == Int(CC_STOKES)
         return stokes_condition
     elseif Int(cc) == Int(CC_EULER)
@@ -60,7 +60,7 @@ function current_criterion(cc)
     end
 end
 
-function parameter_criterion(pc)
+function parameter_condition_factory(pc)
     if Int(pc) == Int(PC_LENGTH)
         return length_condition
     elseif Int(pc) == Int(PC_PERIOD)
@@ -70,7 +70,7 @@ function parameter_criterion(pc)
     end
 end
 
-function parameter_criterion_constant(pc, P, d, g)
+function parameter_condition_constant(pc, P, d, g)
     if Int(pc) == Int(PC_LENGTH)
         return  P / d
     elseif Int(pc) == Int(PC_PERIOD)
@@ -80,7 +80,7 @@ function parameter_criterion_constant(pc, P, d, g)
     end
 end
 
-function nonlinear_system_base(du, u, N, _height_condition, pc_equation, cc_equation)
+function nonlinear_system_base!(du, u, N, _height_condition, _parameter_condition, _current_condition)
     for m in 0:N
         du[m+1] = kinematic_surface_condition(u, N, m)
         du[N+1+m+1] = dynamic_surface_condition(u, N, m)
@@ -90,14 +90,14 @@ function nonlinear_system_base(du, u, N, _height_condition, pc_equation, cc_equa
     
     du[2N+4] = _height_condition(u,N)
 
-    du[2N+5] = pc_equation(u,N)
+    du[2N+5] = _parameter_condition(u,N)
 
-    du[2N+6] = cc_equation(u,N)
+    du[2N+6] = _current_condition(u,N)
     return nothing
 end
 
-function nonlinear_system_base(du, u, N, _height_condition, pc_equation, cc_equation, _power_condition)
-    nonlinear_system_base(du, u, N, _height_condition, pc_equation, cc_equation)
+function nonlinear_system_base!(du, u, N, _height_condition, _parameter_condition, _current_condition, _power_condition)
+    nonlinear_system_base!(du, u, N, _height_condition, _parameter_condition, _current_condition)
 
     du[2N+7] = _power_condition(u, N)
     return nothing

--- a/src/shoaling.jl
+++ b/src/shoaling.jl
@@ -56,18 +56,19 @@ propagating in water of changing depth from `d` to `d_p` using Fourier Approxima
 function fourier_approx!(u, d, d_p, F, T; cc=CC_STOKES, N=10)
     init_conditions!(d_p / d, u, N)
 
-    pc_equation(u,N) = period_condition(u, N, T)
-    pwr_condition(u,N) = power_condition(u,N,F)
+    _period_condition(u,N) = period_condition(u, N, T)
+    _power_condition(u,N) = power_condition(u,N,F)
+    _current_condition = current_condition_factory(cc)
 
-    nonlinear_system(du,u,p) = nonlinear_system_base(
+    _nonlinear_system!(du,u,p) = nonlinear_system_base!(
         du, u, N,
         height_condition,
-        pc_equation,
-        current_criterion(cc),
-        pwr_condition
+        _period_condition,
+        _current_condition,
+        _power_condition
     )
 
-    problem = NonlinearProblem(nonlinear_system, u[1:2N+7])
+    problem = NonlinearProblem(_nonlinear_system!, u[1:2N+7])
     solution = solve(problem, RobustMultiNewton())
     u[1:2N+7] = solution.u
     return nothing

--- a/src/steady.jl
+++ b/src/steady.jl
@@ -31,26 +31,26 @@ propagating in water of depth `d` using Fourier Approximation Method.
 function fourier_approx(d, H, P; pc=PC_LENGTH, cc=CC_STOKES, N=10, M=1, g=9.81)
     u = init_conditions(d, H, P, Int(pc), N, M)
 
-    pc_constant = parameter_criterion_constant(pc, P, d, g)
-    pc_equation(u,N) = parameter_criterion(pc)(
+    parameter_constant = parameter_condition_constant(pc, P, d, g)
+    _parameter_condition(u,N) = parameter_condition_factory(pc)(
         u,N,
-        pc_constant
+        parameter_constant
     )
 
-    cc_equation = current_criterion(cc)
+    _current_condition = current_condition_factory(cc)
 
     for m in 1:M
         _height_condition(u, N) = height_condition(u, N, H / d * m / M)
 
-        nonlinear_system(du,u,p) = nonlinear_system_base(
+        _nonlinear_system!(du,u,p) = nonlinear_system_base!(
             du,u,N,
             _height_condition,
-            pc_equation,
-            cc_equation
+            _parameter_condition,
+            _current_condition
             
         )
 
-        problem = NonlinearProblem(nonlinear_system, u)
+        problem = NonlinearProblem(_nonlinear_system!, u)
         solution = solve(problem, RobustMultiNewton())
         u[:] = solution.u
     end


### PR DESCRIPTION
Update  of names to follow standard:

-  in place functions names include `!` as 'nonlinear_system_base!' #15 
- arguments and variables, that are functions, have names starting with `_` like `_height_condition`
- change from `pc_criterion` and `cc_criterion` to `parameter_condition` and `current_condition`
- functions returning functions have names ending with `factory` like `current_condition_factory`

