### PR TITLE
fixed stream_eigen function - clear variable names and inbounds

### DIFF
--- a/src/nonlinear_system.jl
+++ b/src/nonlinear_system.jl
@@ -5,7 +5,12 @@ using ..Output: wave_power, wave_period
 using ..Params
 
 function stream_eigenfunction(hiperbolic,trigonometric,u,N,m,j)
-    return u[N+1+j] * hiperbolic(j * u[m+1]) / cosh(j * u[2N+D_INDEX]) * trigonometric(j * m * π / N)
+    @inbounds begin
+        u_j = u[N + 1 + j]
+        u_m = u[m + 1]
+        u_depth = u[2 * N + D_INDEX]
+    end
+    return u_j * hiperbolic(j * u_m) / cosh(j * u_depth) * trigonometric(j * m * π / N)
 end
 
 function mean_depth_condition(u,N)


### PR DESCRIPTION
Hi, @pankogito, please look at the fixed issue. I have kept the variable names clearer and added inbounds as multiple functions ahead use stream_eigenfunction, so this reduces the time for bounds checking. Thank you!  