### PR TITLE
STW-122 Surface Tension Coefficient

### DIFF
--- a/src/condition.jl
+++ b/src/condition.jl
@@ -24,6 +24,17 @@ function dynamic_surface_condition(w::WaveStruct,m)
     return pressure(w,kx,kz)
 end
 
+function dynamic_condition_factory(config::Params.ConfigStruct)
+    if config.wave_type == Params.GRAVITY_WAVE
+
+        return dynamic_surface_condition
+
+    else
+        throw(error("Unknown wave type $pc"))
+    end
+
+end
+
 function height_condition(w::WaveStruct, p)
     return w.eta.max - w.eta.min - w.D * p
 end

--- a/src/dimensional_factor.jl
+++ b/src/dimensional_factor.jl
@@ -31,6 +31,10 @@ function pressure_factor(kd,d,g,rho)
     return kd/d / g / rho
 end
 
+function surface_tension_factor(kd,d,g,rho)
+    return (kd/d)^2 / g / rho
+end
+
 function velocity_struct_factor(w_c,u,g,d)
     kd = w_c.D(w_c,u)
 
@@ -71,6 +75,7 @@ function dimensional_factor_compiler(d,physics)
 	    (w_c, u) -> period_factor(     w_c.D(w_c,u), d, g),	        # T
 	    (w_c, u) -> power_factor(      w_c.D(w_c,u), d, g, rho),	# F
         (w_c, u) -> pressure_factor(   w_c.D(w_c,u), d, g, rho),
+        (w_c, u) -> surface_tension_factor( w_c.D(w_c,u), d, g, rho),
 	    (w_c, u) -> 1	                                            # raw
     )
 end

--- a/src/params.jl
+++ b/src/params.jl
@@ -18,6 +18,13 @@ end
     INVALID_ELEVATION = 0
 end
 
+@enum WaveType begin
+    GRAVITY_WAVE = 1
+    CAPILLARY_WAVE = 2
+    GRAVITY_CAPILLARY_WAVE = 3
+    INVALID_WAVE = 0
+end
+
 function T(P,pc)
     return Int(pc) == Int(PC_PERIOD) ? P : nothing
 end
@@ -30,15 +37,18 @@ struct ConfigStruct
     cc::CurrentCriterion
     pc::ParameterCriterion
     eta_type::ElevationType
+    wave_type::WaveType
 
     ConfigStruct(;
         cc=CC_INVALID,
         pc=PC_INVALID,
-        eta_type=INVALID_ELEVATION
+        eta_type=INVALID_ELEVATION,
+        wave_type=GRAVITY_WAVE,
     ) = new(
         typeof(cc) == Int ? CurrentCriterion(cc) : cc,
         typeof(pc) == Int ? ParameterCriterion(pc) : pc,
-        typeof(eta_type) == Int ? ElevationType(eta_type) : eta_type
+        typeof(eta_type) == Int ? ElevationType(eta_type) : eta_type,
+        typeof(wave_type) == Int ? ElevationType(wave_type) : wave_type
     )
 end
 
@@ -47,5 +57,7 @@ export CurrentCriterion, CC_EULER, CC_STOKES
 export ParameterCriterion, PC_LENGTH, PC_PERIOD
 
 export ElevationType
+
+export WaveType
 
 end

--- a/src/physics.jl
+++ b/src/physics.jl
@@ -1,16 +1,19 @@
 module Physics
 
-export G, RHO
+export G, RHO, SIGMA
 
 const G = 9.81
 
 const RHO = 1000.0
 
+const SIGMA = 0.0073
+
 struct PhysicsStruct
     g::AbstractFloat
     rho::AbstractFloat
+    sigma::AbstractFloat
 end
 
-const DEFAULT_PHYSICS = PhysicsStruct(G,RHO)
+const DEFAULT_PHYSICS = PhysicsStruct(G,RHO,SIGMA)
 
 end

--- a/src/shoaling.jl
+++ b/src/shoaling.jl
@@ -15,7 +15,8 @@ using ..Wave: WaveStruct
 using ..Steady: fourier_approx
 using ..NonlinearSystem: fourier_approx_base, ConditionStruct
 using ..Condition: period_condition, power_condition, current_condition_factory, height_condition,
-        kinematic_surface_condition, dynamic_surface_condition, mean_depth_condition
+        kinematic_surface_condition, dynamic_surface_condition, mean_depth_condition,
+        dynamic_condition_factory
 """
     topo_approx(d, H, L; cc=2, N=10, g=G)
 
@@ -33,11 +34,13 @@ for wave of length `L` and height `H`.
 # Output
 - `K`: vector of shoaling coefficient values
 """
-function topo_approx(d, H, L; cc=CC_STOKES, N=10, g=G, rho = RHO, eta_type=Params.FOURIER_ELEVATION)
+function topo_approx(d, H, L; cc=CC_STOKES, N=10, g=G, rho = RHO, sigma=0,
+        eta_type=Params.FOURIER_ELEVATION
+    )
     
     config = Params.ConfigStruct(pc=PC_LENGTH, cc=cc, eta_type=eta_type)
    
-    physics = Physics.PhysicsStruct(g,rho)
+    physics = Physics.PhysicsStruct(g,rho,sigma)
 
     return topo_approx(d,H,L,config,physics,N=N)
 end
@@ -79,7 +82,7 @@ function update_depth_fourier_approx(w, d, d_p, F, T, idx; cc=CC_STOKES, N=10, g
     
     config = Params.ConditionStruct(cc=cc, eta_type=eta_type)
 
-    physics = Physics.PhysicsStruct(g,rho)
+    physics = Physics.PhysicsStruct(g,rho,sigma)
 
     return update_depth_fourier_approx(w,d,d_p,F,T,idx,config,physics,N=N)
 end
@@ -101,7 +104,7 @@ function update_depth_fourier_approx(w, d, d_p, F, T, idx,config,physics; N=10)
 
     conditions = [
         ConditionStruct(kinematic_surface_condition, 0:N),
-        ConditionStruct(dynamic_surface_condition, 0:N),
+        ConditionStruct(dynamic_condition_factory(config), 0:N),
         ConditionStruct(mean_depth_condition),
         ConditionStruct(period_condition),
         ConditionStruct(current_condition_factory(config.cc)),

--- a/src/steady.jl
+++ b/src/steady.jl
@@ -15,7 +15,7 @@ using ..NonlinearSystem: fourier_approx_base, ConditionStruct
 using ..Condition: parameter_condition_factory,
     current_condition_factory, height_condition,
     kinematic_surface_condition, dynamic_surface_condition,
-    mean_depth_condition
+    mean_depth_condition, dynamic_condition_factory
 """
     fourier_approx(d, H, P; pc=1, cc=1, N=10, M=1, g=G)
 
@@ -42,13 +42,13 @@ propagating in water of depth `d` using Fourier Approximation Method.
 - `u[2N+6]`: mean flow velocity *Ū√(k/g)*
 - `u[2N+7]`: wave height *kH*
 """
-function fourier_approx(d, H, P; pc=PC_LENGTH, cc=CC_STOKES, N=10, M=1, g=G,rho=RHO,
+function fourier_approx(d, H, P; pc=PC_LENGTH, cc=CC_STOKES, N=10, M=1, g=G,rho=RHO,sigma=SIGMA,
     eta_type::ElevationType = Params.FOURIER_ELEVATION
     )
 
     config = Params.ConfigStruct(cc=cc, pc=pc, eta_type=eta_type)
 
-    physics = Physics.PhysicsStruct(g,rho) 
+    physics = Physics.PhysicsStruct(g,rho,sigma) 
 
     return fourier_approx(d,H,P,config, physics; N=N,M=M)
 end
@@ -79,7 +79,7 @@ function fourier_approx(d, H, P,config::Params.ConfigStruct, physics::Physics.Ph
 
     conditions = [
         ConditionStruct(kinematic_surface_condition,0:N),
-        ConditionStruct(dynamic_surface_condition,0:N),
+        ConditionStruct(dynamic_condition_factory(config),0:N),
         ConditionStruct(mean_depth_condition),
         ConditionStruct(parameter_condition_factory(config.pc)),
         ConditionStruct(current_condition_factory(config.cc)),

--- a/src/wave.jl
+++ b/src/wave.jl
@@ -19,8 +19,9 @@ struct WaveStruct
     T
     F
     P
+    sigma
     raw # u array to keep compatibility with not updated functions (u,N instead of w)
-    WaveStruct(eta,v,D,C,R,H,U,Q,N,L,T,F,P,raw) = new(eta,v,D,C,R,H,U,Q,N,L,T,F,P,raw)
+    WaveStruct(eta,v,D,C,R,H,U,Q,N,L,T,F,P,sigma,raw) = new(eta,v,D,C,R,H,U,Q,N,L,T,F,P,sigma,raw)
 
     # create struct that replaces values given as key words in default
     WaveStruct(
@@ -38,6 +39,7 @@ struct WaveStruct
         T = nothing,
         F = nothing,
         P = nothing,
+        sigma = nothing,
         raw = nothing,
     ) = new(
         eta === nothing ? default.eta : eta,
@@ -53,6 +55,7 @@ struct WaveStruct
         T === nothing ? default.T : T,
         F === nothing ? default.F : F,
         P === nothing ? default.P : P,
+        sigma === nothing ? default.sigma : sigma,
         raw === nothing ? default.raw : raw,
     )
 
@@ -72,6 +75,7 @@ struct WaveStruct
         T = nothing,
         F = nothing,
         P = nothing,
+        sigma = nothing,
         raw = nothing,
     ) = new(
         eta === nothing ? default.eta : (w_c, u) -> eta * df.eta(w_c,u),
@@ -87,6 +91,7 @@ struct WaveStruct
         T   === nothing ? default.T   : (w_c, u) -> T   * df.T(w_c,u),
         F   === nothing ? default.F   : (w_c, u) -> F   * df.F(w_c,u),
         P   === nothing ? default.P   : (w_c, u) -> P   * df.P(w_c,u),
+        sigma === nothing ? default.sigma : (w_c, u) -> sigma   * df.sigma(w_c,u),
         raw === nothing ? default.raw : (w_c, u) -> raw * df.raw(w_c,u),
     )
 
@@ -105,6 +110,7 @@ struct WaveStruct
         (w_c, u) -> nothing,
         (w_c, u) -> nothing,
         (w_c, u) -> nothing,
+        (w_c, u) -> 0,
         (w_c, u) -> u,
     )
 
@@ -123,6 +129,7 @@ struct WaveStruct
         compiler.T(inner_compiler,u),
         compiler.F(inner_compiler,u),
         compiler.P(inner_compiler,u),
+        compiler.sigma(inner_compiler,u),
         compiler.raw(inner_compiler,u),
     )
 


### PR DESCRIPTION
Introduction of constant `SIGMA` for surface tension coefficient and enum `WaveType` to select between:
- `GRAVITY_WAVE`
- `CAPILLARY_WAVE`
-  `GRAVITY_CAPILLARY_WAVE`

For now only `GRAVITY_WAVE` is accepted as valid input so `WaveType` is not exposed to the user.