### PR TITLE
STW-124 Surface Tension

### DIFF
--- a/src/condition.jl
+++ b/src/condition.jl
@@ -2,7 +2,7 @@ module Condition
 
 using ..Wave:WaveStruct
 using ..Output
-using ..Output: indirect_wave_power, pressure
+using ..Output: indirect_wave_power, pressure, indirect_surface_tension
 using ..Params
 
 
@@ -17,17 +17,31 @@ function kinematic_surface_condition(w::WaveStruct,m)
     return w.v.psi(kx,kz) - w.U * (kz - w.D) - w.Q
 end
 
-function dynamic_surface_condition(w::WaveStruct,m)
+function gravity_dynamic_surface_condition(w::WaveStruct,m)
     kx = m/w.N * pi
     kz = w.eta.point(m)
 
     return pressure(w,kx,kz)
 end
 
+function gravity_capillary_dynamic_surface_condition(w::WaveStruct,m)
+    kx = m/w.N * pi
+    kz = w.eta.point(m)
+
+    dz_dx_1 = w.eta.point.dz_dx_1(m)
+    dz_dx_2 = w.eta.point.dz_dx_2(m)
+
+    return pressure(w,kx,kz) - indirect_surface_tension(w.sigma, dz_dx_1, dz_dx_2)
+end
+
 function dynamic_condition_factory(config::Params.ConfigStruct)
     if config.wave_type == Params.GRAVITY_WAVE
 
-        return dynamic_surface_condition
+        return gravity_dynamic_surface_condition
+
+    elseif config.wave_type == Params.GRAVITY_CAPILLARY_WAVE
+
+        return gravity_capillary_dynamic_surface_condition
 
     else
         throw(error("Unknown wave type $pc"))

--- a/src/output.jl
+++ b/src/output.jl
@@ -148,4 +148,17 @@ function elevation(w::WaveStruct,x, df)
     return elevation(w, x * df.L) / df.eta
 end
 
+function surface_tension(w,kx)
+    return indirect_surface_tension(
+        w.sigma,
+        w.eta.z.dz_dx_1(kx),
+        w.eta.z.dz_dx_2(kx)
+    )
+end
+
+function indirect_surface_tension(sigma,kz_d1,kz_d2)
+    return sigma * kz_d2 / (1 + kz_d1^2)^1.5
+end
+
+
 end

--- a/src/shoaling.jl
+++ b/src/shoaling.jl
@@ -15,7 +15,7 @@ using ..Wave: WaveStruct
 using ..Steady: fourier_approx
 using ..NonlinearSystem: fourier_approx_base, ConditionStruct
 using ..Condition: period_condition, power_condition, current_condition_factory, height_condition,
-        kinematic_surface_condition, dynamic_surface_condition, mean_depth_condition,
+        kinematic_surface_condition, mean_depth_condition,
         dynamic_condition_factory
 """
     topo_approx(d, H, L; cc=2, N=10, g=G)

--- a/src/steady.jl
+++ b/src/steady.jl
@@ -14,7 +14,7 @@ using ..Linear
 using ..NonlinearSystem: fourier_approx_base, ConditionStruct
 using ..Condition: parameter_condition_factory,
     current_condition_factory, height_condition,
-    kinematic_surface_condition, dynamic_surface_condition,
+    kinematic_surface_condition,
     mean_depth_condition, dynamic_condition_factory
 """
     fourier_approx(d, H, P; pc=1, cc=1, N=10, M=1, g=G)
@@ -72,6 +72,7 @@ function fourier_approx(d, H, P,config::Params.ConfigStruct, physics::Physics.Ph
         H = H/M,
         L = L,
         T = T,
+        sigma = physics.sigma
     )
 
     # initial conditions

--- a/src/surface.jl
+++ b/src/surface.jl
@@ -87,14 +87,21 @@ function direct_point_der_2(point,m,idx::IndexStruct)
     return (point(m-1) - 2point(m) + point(m+1)) / dkx^2
 end
 
-function direct_elevation_struct(idx)
-    point = EtaSupportStruct(
-        (w_c,u) -> m -> direct_point(u,m,idx),
-        (w_c,u) -> m -> point_x(m,idx),
-        (w_c,u) -> m -> direct_point_der_1(j -> direct_point(u,j,idx),m,idx),
-        (w_c,u) -> m -> direct_point_der_2(j -> direct_point(u,j,idx),m,idx),
-    )
 
+function direct_elevation_struct(idx)
+    _point_x = m -> point_x(m,idx)
+
+    point = (w_c,u) -> begin
+        _point = m -> direct_point(u,m,idx)
+        
+
+        return EtaSupportStruct(
+            _point,
+            _point_x,
+            m-> direct_point_der_1(_point,m,idx),
+            m-> direct_point_der_2(_point,m,idx),
+        )        
+    end
 
     return SurfaceStruct(
         point,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,9 @@ using Test
     # Test: dispersion relation
     ω = √(g * k * tanh(k * d))
     @test k ≈ linear_wave_number(d, ω)
+
+
+    @test SteadyWaves.Output.indirect_surface_tension(1,1,0) ≈ 0
 end
 
 @testset "SteadyWaves.jl - direct elevation" begin
@@ -91,6 +94,7 @@ end
     
     @test abs(w.eta.z.dz_dx_1(π)) < 1e-15
 
+    @test SteadyWaves.Output.surface_tension(w,0) < 0
 end
 
 @testset "SteadyWaves.jl - fourier elevation" begin
@@ -153,6 +157,8 @@ end
     @test pressure(w, X/k, Z/k, df) ≈ rho * g / k * pressure(w, X, Z)
 
     @test 1e-12 > abs(pressure(w,0,w.eta.point(0)))
+
+    @test SteadyWaves.Output.surface_tension(w,0) < 0
 
 end
 


### PR DESCRIPTION
Introduction of `surface_tension` and `indirect_surface_tension` for calculation of surface tension.

Additionally dynamic condition for gravitational capillary waves was created to test surface tension. It will be made accessible to the user at later date.

Bellow results of the simulation.

<img width="944" height="529" alt="tension_g" src="https://github.com/user-attachments/assets/2ce4b99e-d4f8-43a1-92d3-1ede283ec502" />

<img width="944" height="529" alt="tension_gc" src="https://github.com/user-attachments/assets/4295381d-e246-4ae6-a1fd-14cd818edbfb" />
