### PR TITLE
STW-151 Definition Struct

### DIFF
--- a/src/condition.jl
+++ b/src/condition.jl
@@ -93,10 +93,10 @@ function current_condition_factory(config::Params.ConfigStruct)
     end
 end
 
-function parameter_condition_factory(config::Params.ConfigStruct)
-    if config.pc == PC_LENGTH
+function parameter_condition_factory(definition::Params.Definition,config::Params.ConfigStruct)
+    if definition.L !== nothing
         return length_condition
-    elseif config.pc == PC_PERIOD
+    elseif definition.T !== nothing
         return period_condition
     else
         throw(error("Unknown parameter criterion $(config.pc)"))

--- a/src/linear.jl
+++ b/src/linear.jl
@@ -10,8 +10,9 @@ using ..Indirect
 
 using NonlinearSolve
 
-function init(d,P,pc,idx, g=G)
-    k = Int(pc) == Int(PC_LENGTH) ? 2π / P : linear_wave_number(d, 2π / P, g) # wave number (rad/s)
+function init(definition,idx, g=G)
+    d = definition.d
+    k = definition.L !== nothing ? 2π / definition.L : linear_wave_number(d, 2π / definition.T, g) # wave number (rad/s)
     u = zeros(idx.U)
 
     set(u,idx.D,k*d)
@@ -72,6 +73,13 @@ function linear_solution(d,H,P; pc=Params.PC_LENGTH,
 
     idx::IndexStruct = Index.default_indexes(N)
 
+    definition = Params.Definition(
+        d = d,
+        H = H,
+        L = Params.L(P,pc),
+        T = Params.T(P,pc),
+    )
+
     config = Params.ConfigStruct(
         eta_type = eta_type,
         pc = pc,
@@ -89,7 +97,7 @@ function linear_solution(d,H,P; pc=Params.PC_LENGTH,
         df_compiler
     )
 
-    w, df = linear_solution(d,P,config,idx,compiler,df_compiler,g=physics.g)
+    w, df = linear_solution(definition,config,idx,compiler,df_compiler,g=physics.g)
 
     w =  Wave.set_values(w,
             WaveStruct(
@@ -104,9 +112,9 @@ function linear_solution(d,H,P; pc=Params.PC_LENGTH,
     return w, df
 end
 
-function linear_solution(d, P, config::Params.ConfigStruct, idx::IndexStruct, compiler, df_compiler; g=G)
+function linear_solution(definition, config::Params.ConfigStruct, idx::IndexStruct, compiler, df_compiler; g=G)
 
-    k, u = init(d, P, config.pc, idx,g)
+    k, u = init(definition, idx,g)
 
     df = WaveStruct(u, df_compiler, compiler)
 

--- a/src/shoaling.jl
+++ b/src/shoaling.jl
@@ -45,19 +45,27 @@ function topo_approx(d, H, L; cc=CC_STOKES, N=10, g=G, rho = RHO, sigma=0,
     )
     
     config = Params.ConfigStruct(pc=PC_LENGTH, cc=cc, eta_type=eta_type)
+
+    definition = Params.Definition(
+        d = d[1],
+        H = H,
+        L = L,
+        c_e = c_e
+    )
    
     physics = Physics.PhysicsStruct(g,rho,sigma)
 
-    return topo_approx(d,H,L,c_e,config,physics,N=N)
+    return topo_approx(definition,config,physics,d,N=N)
 end
 
-function topo_approx(d, H, L,c_e, config,physics; N=10)
+function topo_approx(definition, config,physics,d; N=10)
+    H = definition.H
     idx = Index.default_indexes(N)
-    k = 2π / L # initial wave number (rad/m
+    k = 2π / definition.L # initial wave number (rad/m)
 
     K = zero(float(d))
     K[1] = 1
-    w, df = fourier_approx(d[1], H, L,c_e,config,physics; N=N)
+    w, df = fourier_approx(definition,config,physics; N=N)
 
     wd = dimensional(w,df)
 

--- a/src/steady.jl
+++ b/src/steady.jl
@@ -53,7 +53,6 @@ function fourier_approx(d, H, P; pc=PC_LENGTH, cc=CC_STOKES, N=10, M=1, g=G,rho=
     c_e::Union{Nothing,Number}=nothing,
     )
 
-
     config = Params.ConfigStruct(
         cc=cc, pc=pc,
         eta_type=eta_type,
@@ -62,6 +61,15 @@ function fourier_approx(d, H, P; pc=PC_LENGTH, cc=CC_STOKES, N=10, M=1, g=G,rho=
     )
 
     c_e = config.cc == Params.CC_ARBITRARY ? nothing : c_e
+
+    definition = Params.Definition(
+        d = d,
+        H = H,
+        L = Params.L(P,pc),
+        T = Params.T(P,pc),
+        c_e = c_e
+    )
+
     
 
     physics = Physics.PhysicsStruct(g,rho,sigma) 
@@ -70,7 +78,7 @@ function fourier_approx(d, H, P; pc=PC_LENGTH, cc=CC_STOKES, N=10, M=1, g=G,rho=
 
     validate_config(d,H,L,T,config,physics,N,M)
 
-    return fourier_approx(d,H,P,c_e,config, physics; N=N,M=M)
+    return fourier_approx(definition,config, physics; N=N,M=M)
 end
 
 function validate_config(d,H,L,T,config,physics,N,M)
@@ -86,39 +94,37 @@ function validate_config(d,H,L,T,config,physics,N,M)
     @assert M > 0
 end
 
-function fourier_approx(d, H, P,c_e, config::Params.ConfigStruct, physics::Physics.PhysicsStruct; N=10, M=1)
-    L , T = Params.L(P,config.pc), Params.T(P,config.pc)
-
+function fourier_approx(definition::Params.Definition, config::Params.ConfigStruct, physics::Physics.PhysicsStruct; N=10, M=1)
     idx = Index.default_indexes(N)
 
     # create default compiler
     compiler = WaveStruct(idx,config)
 
     # create dimensional factor compiler 
-    df_compiler = dimensional_factor_compiler(d, physics)
+    df_compiler = dimensional_factor_compiler(definition.d, physics)
 
     # set dimensionless height, length and period from dimensional value
     # if property is nothing given change is skipped
     compiler = Wave.set_compilator_values(
         compiler,
         WaveStruct(
-            H = H/M,
-            L = L,
-            T = T,
+            H = definition.H/M,
+            L = definition.L,
+            T = definition.T,
             sigma = physics.sigma,
-            c_e = c_e
+            c_e = definition.c_e
         ),
         df_compiler,
     )
 
     # initial conditions
-    w, _ = Linear.linear_solution(d, P, config, idx, compiler, df_compiler)
+    w, _ = Linear.linear_solution(definition, config, idx, compiler, df_compiler)
 
     conditions = [
         ConditionStruct(kinematic_surface_condition,0:N),
         ConditionStruct(dynamic_condition_factory(config),0:N),
         ConditionStruct(mean_depth_condition),
-        ConditionStruct(parameter_condition_factory(config)),
+        ConditionStruct(parameter_condition_factory(definition,config)),
         ConditionStruct(current_condition_factory(config)),
         ConditionStruct(height_condition)
     ]
@@ -127,7 +133,7 @@ function fourier_approx(d, H, P,c_e, config::Params.ConfigStruct, physics::Physi
 
     for m in 1:M
         # update height
-        compiler = Wave.set_compilator_values(compiler, WaveStruct(H = H * m/M), df_compiler)
+        compiler = Wave.set_compilator_values(compiler, WaveStruct(H = definition.H * m/M), df_compiler)
 
         w = fourier_approx_base(w.raw,compiler,conditions)
     end
@@ -140,7 +146,7 @@ function fourier_approx(d, H, P,c_e, config::Params.ConfigStruct, physics::Physi
 
 end
 
-function dimensionless_fourier_approx(kd, kH,config::Params.ConfigStruct;dimensionless_sigma=0, N=10)
+function dimensionless_fourier_approx(definition::Params.Definition,config::Params.ConfigStruct;dimensionless_sigma=0, N=10)
     idx = Index.dynamic_indexes(N,
         eta=1:N+1,
         psi=1:N,
@@ -157,8 +163,8 @@ function dimensionless_fourier_approx(kd, kH,config::Params.ConfigStruct;dimensi
     compiler = Wave.set_compilator_values(
         compiler,
         WaveStruct(
-            D = kd,
-            H = kH,
+            D = definition.d,
+            H = definition.H,
             sigma = dimensionless_sigma,
             L = 2pi,
         )

--- a/src/system/params.jl
+++ b/src/system/params.jl
@@ -113,6 +113,24 @@ struct ConfigStruct
     )
 end
 
+struct Definition
+    d
+    H
+    F
+    L
+    T
+    c_e
+
+    Definition(;
+        d=nothing,
+        H=nothing,
+        F=nothing,
+        L=nothing,
+        T=nothing,
+        c_e=nothing
+    ) =new(d, H, F, L, T, c_e)
+end
+
 export CurrentCriterion, CC_EULER, CC_STOKES
 
 export ParameterCriterion, PC_LENGTH, PC_PERIOD

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -317,16 +317,20 @@ end
     H = kH/k
 
 
-    @time w, _ = Steady.fourier_approx(d,H,L,nothing,Params.ConfigStruct(
-        eta_type=Params.FOURIER_ELEVATION,
-        cc=Params.CC_EULER,
-        pc=Params.PC_LENGTH,
+    @time w, _ = Steady.fourier_approx(
+        Params.Definition(d=d,H=H,L=L),
+        Params.ConfigStruct(
+            eta_type=Params.FOURIER_ELEVATION,
+            cc=Params.CC_EULER,
+            pc=Params.PC_LENGTH,
         ),
         Physics.DEFAULT_PHYSICS,
         N=N
     )
 
-    @time wd, _ = Steady.dimensionless_fourier_approx(kd,kH,Params.ConfigStruct(
+    @time wd, _ = Steady.dimensionless_fourier_approx(
+        Params.Definition(d=kd,H=kH),
+        Params.ConfigStruct(
         eta_type=Params.FOURIER_ELEVATION,
         cc=Params.CC_EULER
         ),
@@ -346,10 +350,15 @@ end
 
     @test w.U ≈ wd.U
 
-    @time wd, _ = Steady.dimensionless_fourier_approx(kd,kH,Params.ConfigStruct(
-        eta_type=Params.FOURIER_ELEVATION,
-        cc=Params.CC_EULER,
-        indirect_celerity = true,
+    @time wd, _ = Steady.dimensionless_fourier_approx(
+        Params.Definition(
+            d=kd,
+            H=kH
+        ),
+        Params.ConfigStruct(
+            eta_type=Params.FOURIER_ELEVATION,
+            cc=Params.CC_EULER,
+            indirect_celerity = true,
         ),
         dimensionless_sigma = 0,
         N = N


### PR DESCRIPTION
Introduction of `Definition` struct that collect  parameters that define shape of the wave. `L, T, H,F,d,c_e`

In the future it can simplify Config struct via removal of `CC` and `PC` that require now set up in two places.

Additionally it can be used to simplify functions where waves are iteratively change like `furrier_approx` and `topo_approx` via creation of function that conform previous solution to arbitrary values.