### PR TITLE
STW-159 Removal of PC from config

### DIFF
--- a/src/condition.jl
+++ b/src/condition.jl
@@ -100,7 +100,7 @@ function parameter_condition_factory(definition::Params.Definition,config::Param
     elseif definition.T !== nothing
         return period_condition
     else
-        throw(error("Unknown parameter criterion $(config.pc)"))
+        throw(error("Both L  and T are nothing"))
     end
 end
 

--- a/src/linear.jl
+++ b/src/linear.jl
@@ -82,22 +82,11 @@ function linear_solution(d,H,P; pc=Params.PC_LENGTH,
 
     config = Params.ConfigStruct(
         eta_type = eta_type,
-        pc = pc,
         cc = Params.CC_ARBITRARY,
     )
 
-    df_compiler = DimensionalFactor.dimensional_factor_compiler(d,physics)
 
-    compiler = WaveStruct(idx,config)
-
-
-    compiler = Wave.set_compilator_values(
-        compiler,
-        WaveStruct(H=H,L=Params.L(P,pc),T=Params.T(P,pc)),
-        df_compiler
-    )
-
-    w, df = linear_solution(definition,config,idx,compiler,df_compiler,g=physics.g)
+    w, df = linear_solution(definition,config,physics,idx)
 
     w =  Wave.set_values(w,
             WaveStruct(

--- a/src/shoaling.jl
+++ b/src/shoaling.jl
@@ -44,7 +44,7 @@ function topo_approx(d, H, L; cc=CC_STOKES, N=10, g=G, rho = RHO, sigma=0,
         c_e=nothing,
     )
     
-    config = Params.ConfigStruct(pc=PC_LENGTH, cc=cc, eta_type=eta_type)
+    config = Params.ConfigStruct(cc=cc, eta_type=eta_type)
 
     definition = Params.Definition(
         d = d[1],

--- a/src/steady.jl
+++ b/src/steady.jl
@@ -54,7 +54,7 @@ function fourier_approx(d, H, P; pc=PC_LENGTH, cc=CC_STOKES, N=10, M=1, g=G,rho=
     )
 
     config = Params.ConfigStruct(
-        cc=cc, pc=pc,
+        cc=cc,
         eta_type=eta_type,
         deep_water=deep_water,
         wave_type=wave_type
@@ -62,11 +62,13 @@ function fourier_approx(d, H, P; pc=PC_LENGTH, cc=CC_STOKES, N=10, M=1, g=G,rho=
 
     c_e = config.cc == Params.CC_ARBITRARY ? nothing : c_e
 
+    L , T = Params.L(P,pc), Params.T(P,pc)
+
     definition = Params.Definition(
         d = d,
         H = H,
-        L = Params.L(P,pc),
-        T = Params.T(P,pc),
+        L = L,
+        T = T,
         c_e = c_e
     )
 
@@ -74,7 +76,6 @@ function fourier_approx(d, H, P; pc=PC_LENGTH, cc=CC_STOKES, N=10, M=1, g=G,rho=
 
     physics = Physics.PhysicsStruct(g,rho,sigma) 
 
-    L , T = Params.L(P,config.pc), Params.T(P,config.pc)
 
     validate_config(d,H,L,T,config,physics,N,M)
 
@@ -86,8 +87,7 @@ function validate_config(d,H,L,T,config,physics,N,M)
 
     Physics.validate_parameters(H,L,T,d)
 
-    @assert (L === nothing) || (config.pc === PC_LENGTH)
-    @assert (T === nothing) || (config.pc === PC_PERIOD)
+    @assert (L === nothing) || (T === nothing)
 
     @assert N > 1
 

--- a/src/system/params.jl
+++ b/src/system/params.jl
@@ -95,7 +95,6 @@ end
 
 struct ConfigStruct
     cc::CurrentCriterion
-    pc::ParameterCriterion
     eta_type::ElevationType
     wave_type::WaveType
     deep_water::DepthType
@@ -104,7 +103,6 @@ struct ConfigStruct
 
     ConfigStruct(;
         cc=CC_INVALID,
-        pc=PC_INVALID,
         eta_type=INVALID_ELEVATION,
         wave_type=GRAVITY_WAVE,
         deep_water=SHALLOW_WATER,
@@ -112,7 +110,6 @@ struct ConfigStruct
         k_source=K_DEPTH,
     ) = new(
         typeof(cc) == Int ? CurrentCriterion(cc) : cc,
-        typeof(pc) == Int ? ParameterCriterion(pc) : pc,
         typeof(eta_type) == Int ? ElevationType(eta_type) : eta_type,
         typeof(wave_type) == Int ? ElevationType(wave_type) : wave_type,
         typeof(deep_water) == Bool ? parse_depth_type(deep_water) : deep_water,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -322,7 +322,6 @@ end
         Params.ConfigStruct(
             eta_type=Params.FOURIER_ELEVATION,
             cc=Params.CC_EULER,
-            pc=Params.PC_LENGTH,
         ),
         Physics.DEFAULT_PHYSICS,
         N=N


### PR DESCRIPTION
Removal of `pc` from `ConfigStruct` because it duplicates with `L` and `T` from `Definition` and isn't necessary any longer. 

